### PR TITLE
fix(workflow): remove version specification for pnpm setup

### DIFF
--- a/.github/workflows/vercel-deploy.yaml
+++ b/.github/workflows/vercel-deploy.yaml
@@ -49,7 +49,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
           run_install: true
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -88,7 +87,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
           run_install: true
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## issue
https://github.com/furusake-app/furusake/actions/runs/17017188963/job/48241384204 
```
Run pnpm/action-setup@v4
Running self-installer...
  Error: Multiple versions of pnpm specified:
    - version 10 in the GitHub Action config with the key "version"
    - version pnpm@10.14.0 in the package.json with the key "packageManager"
  Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
      at readTarget (/home/runner/work/_actions/pnpm/action-setup/v4/dist/index.js:1:4742)
      at runSelfInstaller (/home/runner/work/_actions/pnpm/action-setup/v4/dist/index.js:1:3930)
      at async install (/home/runner/work/_actions/pnpm/action-setup/v4/dist/index.js:1:3154)
      at async main (/home/runner/work/_actions/pnpm/action-setup/v4/dist/index.js:1:445)
  Error: Error: Multiple versions of pnpm specified:
    - version 10 in the GitHub Action config with the key "version"
    - version pnpm@10.14.0 in the package.json with the key "packageManager"
  Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```

## description

pnpmバージョン指定をpackageManagerだけに

## screenshots (optional)

